### PR TITLE
img2img for intel mac

### DIFF
--- a/ldm/models/diffusion/ddim.py
+++ b/ldm/models/diffusion/ddim.py
@@ -18,8 +18,10 @@ class DDIMSampler(object):
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
-            if attr.device != torch.device("cuda"):
-                attr = attr.to(torch.device("cuda"))
+            # if attr.device != torch.device("cuda"):
+            #     attr = attr.to(torch.device("cuda"))
+            if attr.device != torch.device("mps"):
+                attr = attr.to(torch.float32).to(torch.device("mps")).contiguous()
         setattr(self, name, attr)
 
     def make_schedule(self, ddim_num_steps, ddim_discretize="uniform", ddim_eta=0., verbose=True):

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -40,7 +40,8 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
+    # model.cuda()
+    model.to("mps")
     model.eval()
     return model
 
@@ -199,7 +200,8 @@ def main():
     config = OmegaConf.load(f"{opt.config}")
     model = load_model_from_config(config, f"{opt.ckpt}")
 
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    # device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
     model = model.to(device)
 
     if opt.plms:
@@ -242,7 +244,8 @@ def main():
 
     precision_scope = autocast if opt.precision == "autocast" else nullcontext
     with torch.no_grad():
-        with precision_scope("cuda"):
+        # with precision_scope("cuda"):
+        with nullcontext("mps"):
             with model.ema_scope():
                 tic = time.time()
                 all_samples = list()


### PR DESCRIPTION
Hey, thanks for this repo. txt2img runs fine on my 2019 Intel MBP with an AMD Radeon PRO 5500M.

I've been trying to get img2img to work though. I've adjusted the files similarly to how you adjusted them for txt2img, and I get through decoding the image to 100%... Then I get a segfault.

```
Decoding image:  95%|█████████▌| 38/40 [01:15<00:07,  3.83s/it]

Decoding image:  98%|█████████▊| 39/40 [01:20<00:04,  4.09s/it]

Decoding image: 100%|██████████| 40/40 [01:25<00:00,  2.13s/it]
Fatal Python error: Segmentation fault

Thread 0x0000700007774000 (most recent call first):
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/threading.py", line 306 in wait
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/threading.py", line 558 in wait
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/site-packages/tqdm/_monitor.py", line 60 in run
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/threading.py", line 890 in _bootstrap

Current thread 0x0000000117190600 (most recent call first):
  File "/Users/.../stable-diffusion-intel-mac/scripts/img2img.py", line 272 in main
  File "/Users/.../stable-diffusion-intel-mac/scripts/img2img.py", line 296 in <module>
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/runpy.py", line 87 in _run_code
  File "/usr/local/Caskroom/miniconda/base/envs/ldm2/lib/python3.8/runpy.py", line 194 in _run_module_as_main

Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)
```

Any ideas on how to get it to work? I should probably just rent a CUDA GPU, but it'd be nice to get this running locally on a laptop.